### PR TITLE
Fix code scanning alert no. 123: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^15.0.0",
         "serve-static": "^1.15.0",
-        "express-rate-limit": "^7.4.1"
+        "express-rate-limit": "^7.4.1",
+        "lusca": "^1.7.0"
     },
     "devDependencies": {
         "nodemon": "^2.0.2"

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ import Currency from './models/Currency.js';
 import bcrypt from 'bcryptjs';
 import authenticateJWT from './middleware/authMiddleware.js';
 import rateLimit from 'express-rate-limit';
+import lusca from 'lusca';
 
 const app = express();
 connectDB();
@@ -46,6 +47,7 @@ app.use(cors(corsOptions));
 
 app.use(express.json());
 app.use(cookieParser());
+app.use(lusca.csrf());
 app.use('/api', authenticateJWT, router);
 
 // Rate limiter setup


### PR DESCRIPTION
Fixes [https://github.com/Gladius33/HOUB/security/code-scanning/123](https://github.com/Gladius33/HOUB/security/code-scanning/123)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing middleware stack.

1. Install the `lusca` package.
2. Import the `lusca` package in the `server.js` file.
3. Add the `lusca.csrf()` middleware to the Express application after the `cookieParser` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
