### PR TITLE
Fix code scanning alert no. 124: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ app.use(cors(corsOptions));
 app.use(express.json());
 app.use(cookieParser());
 app.use(lusca.csrf());
-app.use('/api', authenticateJWT, router);
+app.use('/api', authenticateJWT, limiter, router);
 
 // Rate limiter setup
 const limiter = rateLimit({


### PR DESCRIPTION
Fixes [https://github.com/Gladius33/HOUB/security/code-scanning/124](https://github.com/Gladius33/HOUB/security/code-scanning/124)

To fix the problem, we need to ensure that the routes protected by the `authenticateJWT` middleware are also rate-limited. This can be achieved by applying the rate limiter middleware to the `/api` routes in addition to the global rate limiter already in place.

- Add the rate limiter middleware to the `/api` routes.
- Ensure that the rate limiter is applied after the `authenticateJWT` middleware to protect the routes effectively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
